### PR TITLE
Add End-to-End Encryption support as opt-in feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "pushbullet-tray",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pushbullet-tray",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
         "electron-prompt": "^1.7.0",
         "electron-squirrel-startup": "^1.0.1",
         "keytar": "^7.9.0",
+        "node-forge": "^1.3.1",
         "ws": "^8.18.1"
       },
       "devDependencies": {
@@ -3914,6 +3915,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-gyp": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pushbullet-tray",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "main": "main.js",
   "scripts": {
     "dev": "electron .",
@@ -18,6 +18,7 @@
     "electron-prompt": "^1.7.0",
     "electron-squirrel-startup": "^1.0.1",
     "keytar": "^7.9.0",
+    "node-forge": "^1.3.1",
     "ws": "^8.18.1"
   },
   "build": {


### PR DESCRIPTION
This PR implements End-to-End Encryption support for the Pushbullet tray application to resolve the issue where users had to disable E2EE on their Pushbullet account to receive notifications.

## Changes
- Implement AES-256-GCM decryption with PBKDF2 key derivation
- Add E2EE toggle in tray menu (disabled by default)
- Store encryption password securely in macOS Keychain using keytar
- Handle both encrypted and unencrypted pushes seamlessly
- Decrypt messages in WebSocket handler and API responses
- Graceful fallback when decryption fails

## Testing
Users can now:
1. Enable E2EE in their Pushbullet account
2. Use the tray menu to enable E2EE and enter their encryption password
3. Receive encrypted notifications without issues

Fixes #1

Generated with [Claude Code](https://claude.ai/code)